### PR TITLE
bug(form): multiple files upload

### DIFF
--- a/Components/Field/MultipleFile.php
+++ b/Components/Field/MultipleFile.php
@@ -16,11 +16,11 @@ class MultipleFile extends AbstractField
         return FileType::class;
     }
 
-    protected function getAttributes(): array
+    public function getOptions(): array
     {
-        $attributes = parent::getAttributes();
-        $attributes['multiple'] = true;
+        $options = parent::getOptions();
+        $options['multiple'] = true;
 
-        return $attributes;
+        return $options;
     }
 }


### PR DESCRIPTION
Multiple is a from option not a attribute

|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |no|	
|BC breaks?     |no|	
|Deprecations?  |no|	
|Fixed tickets  |no|	

Multiple files upload was not working.