### PR TITLE
fix: validation niss-insz number

### DIFF
--- a/Components/ValueObject/RrNumber.php
+++ b/Components/ValueObject/RrNumber.php
@@ -75,6 +75,6 @@ class RrNumber
     
     public function transform(): string
     {
-        return sprintf('%d%d', $this->base, $this->controlNumber);
+        return $this->base . $this->controlNumber;
     }
 }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |yes|
|New feature?   |no|	
|BC breaks?     |no|	
|Deprecations?  |no|	
|Fixed tickets  |no|	

A valid number that ends on 07 failed the validation
Sprintf issue removing leading zero