### PR TITLE
fix: empty values are valid values for choice option value

### DIFF
--- a/FormConfig/FieldChoicesConfig.php
+++ b/FormConfig/FieldChoicesConfig.php
@@ -84,16 +84,14 @@ class FieldChoicesConfig
 
     private function getTopLevel(array $elements): array
     {
-        return \array_filter(
-            \array_map(
-                function ($element) {
-                    if (\is_array($element)) {
-                        return \array_key_first($element);
-                    }
-                    return $element;
-                },
-                $elements
-            )
+        return \array_map(
+            function ($element) {
+                if (\is_array($element)) {
+                    return \array_key_first($element);
+                }
+                return $element;
+            },
+            $elements
         );
     }
 


### PR DESCRIPTION
fix: empty values (0, null, false, """ "0") are valid values for choice option value

|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	
