### PR TITLE
release: 1.2.15

### DIFF
--- a/FormConfig/FieldChoicesConfig.php
+++ b/FormConfig/FieldChoicesConfig.php
@@ -84,16 +84,14 @@ class FieldChoicesConfig
 
     private function getTopLevel(array $elements): array
     {
-        return \array_filter(
-            \array_map(
-                function ($element) {
-                    if (\is_array($element)) {
-                        return \array_key_first($element);
-                    }
-                    return $element;
-                },
-                $elements
-            )
+        return \array_map(
+            function ($element) {
+                if (\is_array($element)) {
+                    return \array_key_first($element);
+                }
+                return $element;
+            },
+            $elements
         );
     }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |yes|
|New feature?   |no|	
|BC breaks?     |no|	
|Deprecations?  |no|	
|Fixed tickets  |no|	

fix: empty values (0, null, false, """ "0") are valid values for choice option value (#114)