### PR TITLE
hotfix: ems_send_confirmation_widget form(form)

### DIFF
--- a/Resources/views/form_theme.html.twig
+++ b/Resources/views/form_theme.html.twig
@@ -43,6 +43,6 @@
                 {{ 'ems_send_confirmation'|trans({}, ems_translation_domain) }}
             </button>
         </div>
-        {{ form(form) }}
+        {{- block('form_widget_simple') -}}
     </div>
 {%- endblock -%}


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |yes|
|New feature?   |no|	
|BC breaks?     |no|	
|Deprecations?  |no|	
|Fixed tickets  |no|	

the form theme of the confirmation_widget blocks the form rendering