### PR TITLE
fix: use the session to save a generated confirmation code

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -52,6 +52,7 @@
         <service id="emsf.service.verification" class="EMS\FormBundle\Service\Verification\VerificationService">
             <argument type="service" id="emsch.api"/>
             <argument type="service" id="emsch.manager.client_request"/>
+            <argument type="service" id="session"/>
         </service>
         <service id="emsf.validator.verification_code" class="EMS\FormBundle\Components\Constraint\IsVerificationCodeValidator">
             <argument type="service" id="emsf.service.verification"/>

--- a/Service/Verification/VerificationService.php
+++ b/Service/Verification/VerificationService.php
@@ -7,6 +7,7 @@ namespace EMS\FormBundle\Service\Verification;
 use EMS\ClientHelperBundle\Helper\Api\ApiService;
 use EMS\ClientHelperBundle\Helper\Api\Client;
 use EMS\ClientHelperBundle\Helper\Elasticsearch\ClientRequestManager;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 final class VerificationService
 {
@@ -14,23 +15,49 @@ final class VerificationService
     private $apiService;
     /** @var ClientRequestManager */
     private $clientRequestManager;
+    /** @var SessionInterface */
+    private $session;
+    /** @var bool */
+    private $savedInSession;
 
-    public function __construct(ApiService $apiService, ClientRequestManager $clientRequestManager)
+    public function __construct(ApiService $apiService, ClientRequestManager $clientRequestManager, SessionInterface $session, bool $savedInSession = true)
     {
         $this->apiService = $apiService;
         $this->clientRequestManager = $clientRequestManager;
+        $this->session = $session;
+        $this->savedInSession = $savedInSession;
     }
 
     public function create(string $value): ?string
     {
-        return $this->getApiClient()->createFormVerification($value);
+        if (!$this->savedInSession) {
+            return $this->getApiClient()->createFormVerification($value);
+        }
+
+        $verificationCode =  $this->session->get($this->getSessionKey($value), null);
+
+        if ($verificationCode === null) {
+            $verificationCode = \sprintf("%06d", \mt_rand(1, 999999));
+            $this->session->set($this->getSessionKey($value), $verificationCode);
+        }
+
+        return $verificationCode;
     }
 
     public function verify(string $value, string $expectedCode): bool
     {
-        $verificationCode = $this->getApiClient()->getFormVerification($value);
+        if ($this->savedInSession) {
+            $verificationCode =  $this->session->get($this->getSessionKey($value), false);
+        } else {
+            $verificationCode = $this->getApiClient()->getFormVerification($value);
+        }
 
         return $verificationCode === $expectedCode;
+    }
+
+    private function getSessionKey(string $value): string
+    {
+        return \sprintf('EMS_CC_[%s]', $value);
     }
 
     private function getApiClient(): Client


### PR DESCRIPTION
Due to performance issue. No need to handle a timeout has it will disappear with the session

|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |Y|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	
