### PR TITLE
fix: choice sorting

### DIFF
--- a/FormConfig/FieldChoicesConfig.php
+++ b/FormConfig/FieldChoicesConfig.php
@@ -148,10 +148,16 @@ class FieldChoicesConfig
         }
 
         if ($this->sort === 'label_alpha') {
-            \ksort($list);
+            $collator = new \Collator('en');
+            uksort($list, function ($a, $b) use ($collator) {
+                return $collator->compare($a, $b);
+            });
         }
         if ($this->sort === 'value_alpha') {
-            \asort($list);
+            $collator = new \Collator('en');
+            uasort($list, function ($a, $b) use ($collator) {
+                return $collator->compare($a, $b);
+            });
         }
 
         if ($firstValue === null ||  $firstValue === '') {

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 		"symfony/security": "^4.4",
 		"symfony/twig-bridge": "^4.4",
 		"symfony/validator": "^4.4",
+		"symfony/intl": "^5.1",
 		"twig/twig" : "~2.10.0"
 	},
 	"require-dev" : {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |yes|
|New feature?   |no|	
|BC breaks?     |no|	
|Deprecations?  |no|	
|Fixed tickets  |no|	

https://www.php.net/manual/en/class.collator.php:
Provides string comparison capability with support for appropriate locale-sensitive sort orderings.
