### PR TITLE
fix: validators en translations

### DIFF
--- a/Resources/translations/validators.en.xlf
+++ b/Resources/translations/validators.en.xlf
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="niss_insz">
+                <source>The social security number "{{string}}" is invalid.</source>
+                <target>The social security number "{{string}}" is invalid.</target>
+            </trans-unit>
+            <trans-unit id="belgium_phone">
+                <source>The phone number "{{string}}" is invalid.</source>
+                <target>The phone number "{{string}}" is invalid.</target>
+            </trans-unit>
+            <trans-unit id="confirm_email">
+                <source>The "{{field1}}" and "Confirm {{field2}}" fields must match.</source>
+                <target>The "{{field1}}" and "Confirm {{field2}}" fields must match.</target>
+            </trans-unit>
+            <trans-unit id="confirm_label">
+                 <source>Confirm %field%</source>
+                 <target>Confirm %field%</target>
+            </trans-unit>
+            <trans-unit id="date_label">
+                <source>%label_date% (dd/mm/yyyy)</source>
+                <target>%label_date% (dd/mm/yyyy)</target>
+            </trans-unit>
+            <trans-unit id="time_label">
+                <source>%label_time% (hh:mm)</source>
+                <target>%label_time% (hh:mm)</target>
+            </trans-unit>
+            <trans-unit id="confirm_code_invalid">
+                <source>The confirmation code "{{code}}" is not valid.</source>
+                <target>The confirmation code "{{code}}" is not valid.</target>
+            </trans-unit>
+            <trans-unit id="confirm_code_missing">
+                <source>You have not requested a confirmation code.</source>
+                <target>You have not requested a confirmation code.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   ||	
|BC breaks?     ||	
|Deprecations?  ||	
|Fixed tickets  ||	

Make EN translations of validators work when default language is other then EN