### PR TITLE
fix: bind hashcash validation to the current session (#170)

### DIFF
--- a/Security/Guard.php
+++ b/Security/Guard.php
@@ -44,13 +44,20 @@ class Guard
             return;
         }
 
+        $formData = $request->get('form', []);
+        $submittedToken = $formData['_token'] ?? null;
+
+        if (! \is_string($submittedToken)) {
+            throw new \Exception('guard check validation requires a non empty string csrf token in the submitted formData _token field');
+        }
+
         $header = $request->headers->get('x-hashcash');
 
-        if (null === $header || !is_string($header)) {
+        if (! \is_string($header)) {
             throw new \Exception('x-hashcash header missing');
         }
 
-        $hashCash = new HashcashToken($header);
+        $hashCash = new HashcashToken($header, $submittedToken);
 
         if (!$hashCash->isValid($this->difficulty)) {
             throw new \Exception('invalid hashcash token');

--- a/Security/HashcashToken.php
+++ b/Security/HashcashToken.php
@@ -10,18 +10,25 @@ class HashcashToken
     private $nonce;
     /** @var string */
     private $data;
+    /** @var string */
+    private $token;
 
-    public function __construct(string $header)
+    public function __construct(string $header, string $token)
     {
         list($hash, $nonce, $data) = explode('|', $header);
 
         $this->hash = $hash;
         $this->nonce = $nonce;
         $this->data = $data;
+        $this->token = $token;
     }
 
     public function isValid(int $difficulty): bool
     {
+        if ($this->data !== $this->token) {
+            return false;
+        }
+
         if ('0' !== substr($this->hash, 0, 1)) {
             return false;
         }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   ||	
|BC breaks?     ||	
|Deprecations?  ||	
|Fixed tickets  ||	

* fix: bind hashcash validation to the current session

* ref: simplify null is_string test