### PR TITLE
fix: nullable properties must not be accessed before initialization

### DIFF
--- a/src/Components/Constraint/IsExpression.php
+++ b/src/Components/Constraint/IsExpression.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Constraint;
  */
 class IsExpression extends Constraint
 {
-    public ?string $expression;
+    public ?string $expression = null;
     public string $message = 'This value is not valid.';
 
     /** @return string[] */

--- a/src/Components/Constraint/IsRequiredIf.php
+++ b/src/Components/Constraint/IsRequiredIf.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Constraint;
  */
 class IsRequiredIf extends Constraint
 {
-    public ?string $expression;
+    public ?string $expression = null;
     public string $message = 'This value should not be blank.';
 
     /** @return string[] */

--- a/src/Components/Constraint/IsRequiredWithout.php
+++ b/src/Components/Constraint/IsRequiredWithout.php
@@ -9,6 +9,6 @@ use Symfony\Component\Validator\Constraint;
  */
 class IsRequiredWithout extends Constraint
 {
-    public ?string $otherField;
+    public ?string $otherField = null;
     public string $message = 'This field is required when {{otherField}} is not present.';
 }

--- a/src/Components/Constraint/IsVerificationCode.php
+++ b/src/Components/Constraint/IsVerificationCode.php
@@ -8,7 +8,7 @@ use Symfony\Component\Validator\Constraint;
 
 final class IsVerificationCode extends Constraint
 {
-    public ?string $field;
+    public ?string $field = null;
     public string $message = 'The confirmation code "{{code}}" is not valid.';
     public string $messageMissing = 'You have not requested a confirmation code.';
 

--- a/src/FormConfig/FieldChoicesConfig.php
+++ b/src/FormConfig/FieldChoicesConfig.php
@@ -11,8 +11,8 @@ class FieldChoicesConfig
     private array $labels;
     /** @var mixed[] */
     private array $choices = [];
-    private ?string $placeholder;
-    private ?string $sort;
+    private ?string $placeholder = null;
+    private ?string $sort = null;
 
     /**
      * @param mixed[] $values

--- a/src/FormConfig/FieldConfig.php
+++ b/src/FormConfig/FieldConfig.php
@@ -10,12 +10,12 @@ class FieldConfig implements ElementInterface
     /** @var string[] */
     private array $class = [];
     private string $className;
-    private ?string $defaultValue;
-    private ?string $label;
-    private ?string $help;
+    private ?string $defaultValue = null;
+    private ?string $label = null;
+    private ?string $help = null;
     /** @var ValidationConfig[] */
     private array $validations = [];
-    private ?FieldChoicesConfig $choices;
+    private ?FieldChoicesConfig $choices = null;
     private AbstractFormConfig $parentForm;
 
     public function __construct(string $id, string $name, string $type, string $className, AbstractFormConfig $parentForm)


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

https://stackoverflow.com/questions/59265625/why-i-am-suddenly-getting-a-typed-property-must-not-be-accessed-before-initiali
> Since PHP 7.4 introduces type-hinting for properties, it is particularly important to provide valid values for all properties, so that all properties have values that match their declared types. A property that has never been assigned doesn't have a null value, but it is on an undefined state, which will never match any declared type. undefined !== null.


